### PR TITLE
Preamble option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ URL: https://github.com/USCbiostats/slurmR, https://slurm.schedmd.com/
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Suggests: rslurm, knitr, rmarkdown, covr, tinytest
 Imports: utils
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,20 +4,19 @@ Minor release.
 
 ## New features
 
-* Added a `preamble` option for Slurm batch scripts. This allows the user to
-  specify commands that need to be added to script, e.g., `module load`.
+*  Added a `preamble` option for Slurm batch scripts. This allows the user to
+   specify commands that need to be added to script, e.g., `module load`.
   
-* `preamble` can be specified via `opts_slurmR$set_preamble()` or directly
-  when calling `Slurm_*apply`.
+*  `preamble` can be specified via `opts_slurmR$set_preamble()` or directly
+   when calling `Slurm_*apply`.
   
-* Added the function `opts_slurmR$reset()`.
+*  Added the function `opts_slurmR$reset()`.
   
 ## Bug fixes
 
-* `sourceSlurm()` was using a file created at `tempdir()` which was deleted,
-  and thus, unavailable to be used by `sbatch`. Tempfiles like those are now
-  created at `dirname(tempdir())`.
-
+*  `sourceSlurm()` was using a file created at `tempdir()` which was deleted,
+   and thus, unavailable to be used by `sbatch`. Tempfiles like those are now
+   created at `dirname(tempdir())`.
 
 # slurmR 0.4-2
 
@@ -25,47 +24,43 @@ Minor release.
 
 ## Bug fixes
 
-* Fixes an user-message issue (not crucial) observed in Fedora and Solaris.
-
+*  Fixes an user-message issue (not crucial) observed in Fedora and Solaris.
 
 # slurmR 0.4-1 (CRAN)
 
 ## Bug fixes
 
-* Fixed bug when collecting failed jobs. slurmR would fail to
-  correctly list failed jobs and thus to collect outputs. This would also
-  would affect when trying to collect partially resubmitted jobs.
+*  Fixed bug when collecting failed jobs. slurmR would fail to
+   correctly list failed jobs and thus to collect outputs. This would also
+   would affect when trying to collect partially resubmitted jobs.
   
-* Slurm options passed via `opts_slurmR` are now passed to
-  `Slurm_*apply` as documented. Thanks to Gregory Penn (gregorypenn) who
-  reported the bug.
+*  Slurm options passed via `opts_slurmR` are now passed to
+   `Slurm_*apply` as documented. Thanks to Gregory Penn (gregorypenn) who
+   reported the bug.
   
-* `slurmr_cmd` now expands the `cmd_path`.
-
+*  `slurmr_cmd` now expands the `cmd_path`.
 
 ## Misc
   
-* Increased code coverage.
+*  Increased code coverage.
 
-* The function `wait_slurm()` is now exported and documented.
+*  The function `wait_slurm()` is now exported and documented.
 
-* Each line in the written R script is now wrapped with a custom
-  `tryCatch` function (`tcq`). On error, this new function will collect both
-  the expression called, the error message, and will quit the R session, so now
-  the user has a better description of possible errors, e.g. missing
-  packages.
-
-
+*  Each line in the written R script is now wrapped with a custom
+   `tryCatch` function (`tcq`). On error, this new function will collect both
+   the expression called, the error message, and will quit the R session, so now
+   the user has a better description of possible errors, e.g. missing
+   packages.
 
 # slurmR 0.3-0
 
-* Name changed from `sluRm` to `slurmR`.
+*  Name changed from `sluRm` to `slurmR`.
 
 # slurmR 0.2-0
 
-* JOSS review (finalizing).
+*  JOSS review (finalizing).
 
 # slurmR 0.1-0
 
-* Added a `NEWS.md` file to track changes to the package.
+*  Added a `NEWS.md` file to track changes to the package.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# slurmR 0.4-3 (CRAN)
+
+Minor release.
+
+## New features
+
+* Added a `preamble` option for Slurm batch scripts. This allows the user to
+  specify commands that need to be added to script, e.g., `module load`.
+  
+* `preamble` can be specified via `opts_slurmR$set_preamble()` or directly
+  when calling `Slurm_*apply`.
+  
+* Added the function `opts_slurmR$reset()`.
+  
+## Bug fixes
+
+* `sourceSlurm()` was using a file created at `tempdir()` which was deleted,
+  and thus, unavailable to be used by `sbatch`. Tempfiles like those are now
+  created at `dirname(tempdir())`.
+
+
 # slurmR 0.4-2
 
 Minor release.
@@ -7,7 +28,7 @@ Minor release.
 * Fixes an user-message issue (not crucial) observed in Fedora and Solaris.
 
 
-# slurmR 0.4-1
+# slurmR 0.4-1 (CRAN)
 
 ## Bug fixes
 

--- a/R/Slurm_EvalQ.R
+++ b/R/Slurm_EvalQ.R
@@ -81,6 +81,7 @@ Slurm_EvalQ <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
+  bash$append(opts_slurmR$get_preamble())
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/Slurm_EvalQ.R
+++ b/R/Slurm_EvalQ.R
@@ -21,7 +21,8 @@ Slurm_EvalQ <- function(
   export_env  = NULL,
   libPaths    = .libPaths(),
   hooks       = NULL,
-  overwrite   = TRUE
+  overwrite   = TRUE,
+  preamble    = NULL
 ) {
 
   # Figuring out what are we doing.
@@ -81,7 +82,7 @@ Slurm_EvalQ <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
-  bash$append(opts_slurmR$get_preamble())
+  bash$append(c(opts_slurmR$get_preamble(), preamble))
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/Slurm_Map.R
+++ b/R/Slurm_Map.R
@@ -165,7 +165,7 @@ Slurm_Map <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
-  # bash$append("export OMP_NUM_THREADS=1") # Otherwise mclapply may crash
+  bash$append(opts_slurmR$get_preamble())
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/Slurm_Map.R
+++ b/R/Slurm_Map.R
@@ -49,7 +49,8 @@ Slurm_Map <- function(
   export_env  = NULL,
   libPaths    = .libPaths(),
   hooks       = NULL,
-  overwrite   = TRUE
+  overwrite   = TRUE,
+  preamble    = NULL
   ) {
 
   # Figuring out the plan
@@ -165,7 +166,7 @@ Slurm_Map <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
-  bash$append(opts_slurmR$get_preamble())
+  bash$append(c(opts_slurmR$get_preamble(), preamble))
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/Slurm_lapply.R
+++ b/R/Slurm_lapply.R
@@ -62,7 +62,8 @@ Slurm_lapply <- function(
   export_env  = NULL,
   libPaths    = .libPaths(),
   hooks       = NULL,
-  overwrite   = TRUE
+  overwrite   = TRUE,
+  preamble    = NULL
   ) {
 
   # Figuring out what are we doing.
@@ -185,7 +186,7 @@ Slurm_lapply <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
-  bash$append(opts_slurmR$get_preamble())
+  bash$append(c(opts_slurmR$get_preamble(), preamble))
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/Slurm_lapply.R
+++ b/R/Slurm_lapply.R
@@ -185,7 +185,7 @@ Slurm_lapply <- function(
     )
 
   bash$add_SBATCH(sbatch_opt)
-  # bash$append("export OMP_NUM_THREADS=1") # Otherwise mclapply may crash
+  bash$append(opts_slurmR$get_preamble())
   bash$Rscript(
     file  = snames("r", job_name = job_name, tmp_path = tmp_path),
     flags = rscript_opt

--- a/R/expand_array_indexes.R
+++ b/R/expand_array_indexes.R
@@ -32,7 +32,7 @@ expand_array_indexes <- function(x) {
     )
 
   # is it simply a number?
-  if (grepl("^[0-9]+$", x))
+  if (grepl("^[[:digit:]]+$", x))
     return(as.integer(x))
 
   # Capturing main job name
@@ -40,10 +40,10 @@ expand_array_indexes <- function(x) {
   x     <- gsub(".+_", "", x)
 
   # Removing possible values of "simulatenous jobs"
-  x <- gsub("%[0-9]+", "", x)
+  x <- gsub("%[[:digit:]]+", "", x)
 
   # Simplest case
-  if (grepl("^[0-9]+$", x))
+  if (grepl("^[[:digit:]]+$", x))
     return(sprintf("%d_%d", jobid, as.integer(x)))
 
   # Removing the brackets
@@ -61,16 +61,16 @@ expand_array_indexes <- function(x) {
 
       step. <- as.integer(gsub(".+[:]", "", i))
       start <- as.integer(gsub("[-].+", "", i))
-      end   <- as.integer(gsub("^[0-9]+[-]|[:].+", "", i))
+      end   <- as.integer(gsub("^[[:digit:]]+[-]|[:].+", "", i))
       ans <- c(ans, seq(start, end, by = step.))
 
-    } else if (grepl("^[0-9]+[-][0-9]+$", i)) { # Case 1: A range
+    } else if (grepl("^[[:digit:]]+[-][[:digit:]]+$", i)) { # Case 1: A range
 
       start <- as.integer(gsub("[-].+", "", i))
       end   <- as.integer(gsub(".+[-]", "", i))
       ans <- c(ans, start:end)
 
-    } else if (grepl("^[0-9]+$", i)) { #A simple number!
+    } else if (grepl("^[[:digit:]]+$", i)) { #A simple number!
       ans <- c(ans, as.integer(i))
     } else
       stop("Unknown expression for a Job Array", call. = FALSE)

--- a/R/makeSlurmCluster.R
+++ b/R/makeSlurmCluster.R
@@ -7,8 +7,8 @@ get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
   })
 
   # Creating job name and file
-  fn   <- tempfile("slurmr-job-")
-  jn   <- gsub(".+(?=slurmr-job-)", "", fn, perl = TRUE)
+  fn   <- tempfile("slurmr-job-", tmpdir = dirname(tempdir()))
+  jn   <- basename(fn) 
   out  <- sprintf("%s/%s.out", tmp_path, jn)
 
   # Writing the script

--- a/R/makeSlurmCluster.R
+++ b/R/makeSlurmCluster.R
@@ -1,4 +1,8 @@
-get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
+get_hosts <- function(
+  ntasks = 1,
+  tmp_path = getwd(),
+  ...
+  ) {
 
   # In case that the host retrival fails, this should be the exit mechanism
   on.exit({
@@ -8,7 +12,7 @@ get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
 
   # Creating job name and file
   fn   <- tempfile("slurmr-job-", tmpdir = dirname(tempdir()))
-  jn   <- basename(fn) 
+  jn   <- basename(fn)
   out  <- sprintf("%s/%s.out", tmp_path, jn)
 
   # Writing the script
@@ -16,6 +20,7 @@ get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
   dat  <- paste(
     "#!/bin/sh",
     paste0("#SBATCH ", parse_flags(dots), collapse = "\n"),
+    paste(opts_slurmR$get_preamble(), collapse = "\n"),
     "echo ==start-hostnames==",
     "srun hostname",
     "sleep infinity",
@@ -77,6 +82,23 @@ get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
 #' nodes in a Slurm environment. The name of the hosts are retrieved and passed
 #' later on to [parallel::makePSOCKcluster].
 #'
+#' It has been the case that R fails to create the cluster with the following
+#' message in the Slurm log file:
+#'
+#' ```
+#' srun: fatal: SLURM_MEM_PER_CPU, SLURM_MEM_PER_GPU, and SLURM_MEM_PER_NODE are mutually exclusive
+#' ```
+#'
+#' In such cases, setting the memory, for example, upfront can solve the problem.
+#' For example:
+#'
+#' ```
+#' cl <- makeSlurmCluster(20, mem = 20)
+#' ```
+#'
+#' If the problem persists, i.e., the cluster cannot be created, make sure that
+#' your Slurm cluster allows Socket connections between nodes.
+#'
 #' @section Maximum number of connections:
 #'
 #' By default, R limits the number of simultaneous connections (see this thread
@@ -117,7 +139,7 @@ get_hosts <- function(ntasks=1, tmp_path = getwd(), ...) {
 makeSlurmCluster <- function(
   n,
   job_name       = random_job_name(),
-  tmp_path       = opts_slurmR$get_tmp_path(),
+  tmp_path       = dirname(tempdir()),
   cluster_opt    = list(),
   max_wait       = 300L,
   verb           = TRUE,
@@ -145,11 +167,19 @@ makeSlurmCluster <- function(
   # an error happens after the creating of the job object.
   on.exit({
     if (exists("job") && ( !exists("cl") || !(inherits(cl, "slurm_cluster")))) {
-      warning(
+      message(
         "An error was detected before returning the cluster object. ",
         "If submitted, we will try to cancel the job and stop the cluster ",
-        "object.", call. = FALSE, immediate. = TRUE
+        "object. Make sure that your cluster supports Socket connections between nodes."
         )
+
+      if (file.exists(job$output)) {
+        message("The logfile of the job follows:")
+        message(cat(readLines(job$output), sep = "\n"))
+      } else {
+        message("No logfile found.")
+      }
+
       e <- tryCatch(parallel::stopCluster(cl), error = function(e) e)
       e <- tryCatch(scancel(get_job_id(job)), error = function(e) e)
       if (inherits(e, "error") && !is.na(get_job_id(job))) {

--- a/R/sbatch.R
+++ b/R/sbatch.R
@@ -132,7 +132,7 @@ sbatch.slurm_job <- function(x, wait = FALSE, submit = TRUE, ...) {
   # Warning that the call has been made and storing the id
   if (!opts_slurmR$get_debug()) {
 
-    get_job_id(x) <- as.integer(gsub(pattern = ".+ (?=[0-9]+$)", "", ans, perl=TRUE))
+    get_job_id(x) <- as.integer(gsub(pattern = ".+ (?=[[:digit:]]+$)", "", ans, perl=TRUE))
     message(" jobid:", get_job_id(x), ".")
 
     # We need to update the job file and the latest submitted job
@@ -167,7 +167,7 @@ sbatch.character <- function(x, wait = FALSE, submit = TRUE, ...) {
   SBATCH   <- read_sbatch(x)
   job_name <- SBATCH["job-name"]
   if (is.na(job_name))
-    job_name <- gsub(".+[/](?=[^/]+$)", "", x, perl=TRUE)
+    job_name <- basename(x)
 
   tmp_opts <- list(...)
   tmp_opts <- coalesce_slurm_options(tmp_opts)
@@ -211,7 +211,7 @@ sbatch.character <- function(x, wait = FALSE, submit = TRUE, ...) {
   message("Submitting job...", appendLF = FALSE)
   ans <- silent_system2(opts_slurmR$get_cmd(), option, stdout = TRUE, wait=TRUE)
 
-  jobid <- as.integer(gsub(pattern = ".+ (?=[0-9]+$)", "", ans, perl=TRUE))
+  jobid <- as.integer(gsub(pattern = ".+ (?=[[:digit:]]+$)", "", ans, perl=TRUE))
   message(" jobid:", jobid, ".")
 
   if (wait)

--- a/R/slurmR.R
+++ b/R/slurmR.R
@@ -1,4 +1,13 @@
 #' A Lightweight Wrapper for 'Slurm'
+#'
+#' 'Slurm', Simple Linux Utility for Resource Management
+#' \url{https://slurm.schedmd.com/}, is a popular 'Linux' based software used to
+#' schedule jobs in 'HPC' (High Performance Computing) clusters. This R package
+#' provides a specialized lightweight wrapper of 'Slurm' with a syntax similar to
+#' that found in the 'parallel' R package. The package also includes a method for
+#' creating socket cluster objects spanning multiple nodes that can be used with
+#' the 'parallel' package.
+#'
 #' @details
 #' To cite slurmR in publications use:
 #'

--- a/R/sourceSlurm.R
+++ b/R/sourceSlurm.R
@@ -48,7 +48,7 @@
 sourceSlurm <- function(
   file,
   job_name    = NULL,
-  tmp_path    = file.path(tempdir(), ".."),
+  tmp_path    = dirname(tempdir()),
   rscript_opt = list(vanilla = TRUE),
   plan        = "submit",
   ...

--- a/README.Rmd
+++ b/README.Rmd
@@ -210,6 +210,28 @@ shown previously) as follows:
 $ slurmr example.R
 ```
 
+## Example 5: Using the preamble
+
+Since version 0.4-3, `slurmR` includes the option `preamble`. This provides a way
+for the user to specify commands/modules that need to be executed before running
+the Rscript. Here is an example using `module load`:
+
+```{r preamble, warning=FALSE}
+# Turning the verbose mode off
+opts_slurmR$verbose_off()
+
+# Setting the preamble can be done globally
+opts_slurmR$set_preamble("module load gcc/6.0")
+
+# Or on the fly
+ans <- Slurm_lapply(1:10, mean, plan = "none", preamble = "module load pandoc")
+
+# Printing out the bashfile
+cat(readLines(ans$bashfile), sep = "\n")
+
+Slurm_clean(ans) # Cleaning after you
+```
+
 ## VS 
 
 There are several ways to enhance R for HPC. Depending on what are your goals/restrictions/preferences, you can use any of the following from this **manually curated** list:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ We can use the function `Slurm_lapply` to distribute computations
 ``` r
 ans <- Slurm_lapply(x, mean, plan = "none")
 #  Warning: [submit = FALSE] The job hasn't been submitted yet. Use sbatch() to submit the job, or you can submit it via command line using the following:
-#  sbatch --job-name=slurmr-job-2bf23ae1b6d3 /home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/01-bash.sh
+#  sbatch --job-name=slurmr-job-680648c64bfe /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/01-bash.sh
 Slurm_clean(ans) # Cleaning after you
 ```
 
@@ -121,9 +121,9 @@ get more info, we can actually set the verbose mode on
 opts_slurmR$verbose_on()
 ans <- Slurm_lapply(x, mean, plan = "none")
 #  --------------------------------------------------------------------------------
-#  [VERBOSE MODE ON] The R script that will be used is located at: /home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/00-rscript.r and has the following contents:
+#  [VERBOSE MODE ON] The R script that will be used is located at: /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/00-rscript.r and has the following contents:
 #  --------------------------------------------------------------------------------
-#  .libPaths(c("/home/george/R/x86_64-pc-linux-gnu-library/3.6", "/usr/local/lib/R/site-library", "/usr/lib/R/site-library", "/usr/lib/R/library"))
+#  .libPaths(c("/home/george/R/x86_64-pc-linux-gnu-library/4.0", "/usr/local/lib/R/site-library", "/usr/lib/R/site-library", "/usr/lib/R/library"))
 #  message("[slurmR info] Loading variables and functions... ", appendLF = FALSE)
 #  Slurm_env <- function (x = "SLURM_ARRAY_TASK_ID") 
 #  {
@@ -149,7 +149,7 @@ ans <- Slurm_lapply(x, mean, plan = "none")
 #      sprintf("%s/%s/%s", tmp_path, job_name, type)
 #  }
 #  TMP_PATH  <- "/home/george/Documents/development/slurmR"
-#  JOB_NAME  <- "slurmr-job-2bf23ae1b6d3"
+#  JOB_NAME  <- "slurmr-job-680648c64bfe"
 #  
 #  # The -tcq- function is a wrapper of tryCatch that on error tries to recover
 #  # the message and saves the outcome so that slurmR can return OK.
@@ -172,19 +172,19 @@ ans <- Slurm_lapply(x, mean, plan = "none")
 #  }
 #  message("done loading variables and functions.")
 #  tcq({
-#    INDICES <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/INDICES.rds")
+#    INDICES <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/INDICES.rds")
 #  })
 #  tcq({
-#    X <- readRDS(sprintf("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/X_%04d.rds", ARRAY_ID))
+#    X <- readRDS(sprintf("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/X_%04d.rds", ARRAY_ID))
 #  })
 #  tcq({
-#    FUN <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/FUN.rds")
+#    FUN <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/FUN.rds")
 #  })
 #  tcq({
-#    mc.cores <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/mc.cores.rds")
+#    mc.cores <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/mc.cores.rds")
 #  })
 #  tcq({
-#    seeds <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/seeds.rds")
+#    seeds <- readRDS("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/seeds.rds")
 #  })
 #  set.seed(seeds[ARRAY_ID], kind = NULL, normal.kind = NULL)
 #  tcq({
@@ -194,24 +194,23 @@ ans <- Slurm_lapply(x, mean, plan = "none")
 #      mc.cores         = mc.cores
 #  )
 #  })
-#  saveRDS(ans, sprintf("/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/03-answer-%03i.rds", ARRAY_ID), compress = TRUE)
+#  saveRDS(ans, sprintf("/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/03-answer-%03i.rds", ARRAY_ID), compress = TRUE)
 #  --------------------------------------------------------------------------------
-#  The bash file that will be used is located at: /home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/01-bash.sh and has the following contents:
+#  The bash file that will be used is located at: /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/01-bash.sh and has the following contents:
 #  --------------------------------------------------------------------------------
 #  #!/bin/sh
-#  #SBATCH --job-name=slurmr-job-2bf23ae1b6d3
-#  #SBATCH --output=/home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/02-output-%A-%a.out
+#  #SBATCH --job-name=slurmr-job-680648c64bfe
+#  #SBATCH --output=/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/02-output-%A-%a.out
 #  #SBATCH --array=1-2
-#  #SBATCH --job-name=slurmr-job-2bf23ae1b6d3
+#  #SBATCH --job-name=slurmr-job-680648c64bfe
 #  #SBATCH --cpus-per-task=1
 #  #SBATCH --ntasks=1
-#  export OMP_NUM_THREADS=1
-#  /usr/lib/R/bin/Rscript  /home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/00-rscript.r
+#  /usr/lib/R/bin/Rscript  /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/00-rscript.r
 #  --------------------------------------------------------------------------------
 #  EOF
 #  --------------------------------------------------------------------------------
 #  Warning: [submit = FALSE] The job hasn't been submitted yet. Use sbatch() to submit the job, or you can submit it via command line using the following:
-#  sbatch --job-name=slurmr-job-2bf23ae1b6d3 /home/george/Documents/development/slurmR/slurmr-job-2bf23ae1b6d3/01-bash.sh
+#  sbatch --job-name=slurmr-job-680648c64bfe /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/01-bash.sh
 Slurm_clean(ans) # Cleaning after you
 ```
 
@@ -337,6 +336,39 @@ headers” (as shown previously) as follows:
 
 ``` bash
 $ slurmr example.R
+```
+
+## Example 5: Using the preamble
+
+Since version 0.4-2, `slurmR` includes the option `preamble`. This
+provides a way for the user to specify commands/modules that need to be
+executed before running the Rscript. Here is an example using `module
+load`:
+
+``` r
+# Turning the verbose mode off
+opts_slurmR$verbose_off()
+
+# Setting the preamble can be done globally
+opts_slurmR$set_preamble("module load gcc/6.0")
+
+# Or on the fly
+ans <- Slurm_lapply(1:10, mean, plan = "none", preamble = "module load pandoc")
+
+# Printing out the bashfile
+cat(readLines(ans$bashfile), sep = "\n")
+#  #!/bin/sh
+#  #SBATCH --job-name=slurmr-job-680648c64bfe
+#  #SBATCH --output=/home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/02-output-%A-%a.out
+#  #SBATCH --array=1-2
+#  #SBATCH --job-name=slurmr-job-680648c64bfe
+#  #SBATCH --cpus-per-task=1
+#  #SBATCH --ntasks=1
+#  module load gcc/6.0
+#  module load pandoc
+#  /usr/lib/R/bin/Rscript  /home/george/Documents/development/slurmR/slurmr-job-680648c64bfe/00-rscript.r
+
+Slurm_clean(ans) # Cleaning after you
 ```
 
 ## VS

--- a/inst/tinytest/test-makeSlurmCluster.R
+++ b/inst/tinytest/test-makeSlurmCluster.R
@@ -3,7 +3,7 @@ if (slurm_available()) {
   cl1 <- tryCatch(makeSlurmCluster(2, time = "01:00:00",
     job_name = "test-makeSlurmCluster"), error = function(e) e)
 
-  if (expect_false(inherits(cl1, "error"))) {
+  if (!inherits(cl1, "error")) {
 
 
   cl2 <- makePSOCKcluster(2)
@@ -19,7 +19,7 @@ if (slurm_available()) {
   stopCluster(cl1)
   stopCluster(cl2)
   } else {
-    print(e)
+    print(cl1)
   }
 
 }

--- a/inst/tinytest/test-makeSlurmCluster.R
+++ b/inst/tinytest/test-makeSlurmCluster.R
@@ -1,7 +1,11 @@
 if (slurm_available()) {
 
-  cl1 <- makeSlurmCluster(2, time = "01:00:00",
-    job_name = "test-makeSlurmCluster")
+  cl1 <- tryCatch(makeSlurmCluster(2, time = "01:00:00",
+    job_name = "test-makeSlurmCluster"), error = function(e) e)
+
+  if (expect_false(inherits(cl1, "error"))) {
+
+
   cl2 <- makePSOCKcluster(2)
 
   set.seed(123155)
@@ -14,6 +18,9 @@ if (slurm_available()) {
 
   stopCluster(cl1)
   stopCluster(cl2)
+  } else {
+    print(e)
+  }
 
 }
 

--- a/inst/tinytest/test-sourceSlurm.R
+++ b/inst/tinytest/test-sourceSlurm.R
@@ -16,7 +16,7 @@ cat("#!/bin/sh", "#SBATCH --n-tasks=1", "print(\"Ok\")", file = tmp, sep="\n")
 suppressWarnings(sourceSlurm(tmp, plan = "none"))
 
 # The last job should be in the form of
-name <- gsub(".+[/](?=[^/]+$)", "", tmp, perl = TRUE)
+name <- basename(tmp)
 path <- paste0(
   opts_slurmR$get_tmp_path(), "/",
   name,

--- a/inst/tinytest/test-utils.R
+++ b/inst/tinytest/test-utils.R
@@ -1,4 +1,4 @@
-tmp <- ifelse(slurm_available(), "/staging/ggv/", tempdir())
+# tmp <- ifelse(slurm_available(), "/staging/ggv/", tempdir())
 x   <- suppressWarnings(
   Slurm_EvalQ(print("Hello"), plan = "none", tmp_path = tmp)
   )
@@ -24,6 +24,5 @@ if (slurm_available()) {
   expect_true(is.vector(status(x)$done))
   Slurm_clean(x)
   expect_equal(Slurm_env("SLURM_ARRAY_TASK_ID"), 1)
-
 
 }

--- a/inst/tinytest/test-utils.R
+++ b/inst/tinytest/test-utils.R
@@ -1,7 +1,7 @@
-# tmp <- ifelse(slurm_available(), "/staging/ggv/", tempdir())
+tmp <- file.path(opts_slurmR$get_tmp_path(), "test-utils")
 x   <- suppressWarnings(
   Slurm_EvalQ(print("Hello"), plan = "none", tmp_path = tmp)
-  )
+)
 expect_true(is.character(whoami()))
 expect_true(dir.exists(paste0(tmp, "/", x$opts_job$`job-name`)))
 Slurm_clean(x)

--- a/man-roxygen/slurm.R
+++ b/man-roxygen/slurm.R
@@ -12,5 +12,8 @@
 #' @param overwrite Logical scalar. When `TRUE`, if the path specified by
 #' `tmp_path/job_name` already exists, it will overwrite it, otherwise the
 #' function returns with an error.
+#' @param preamble Character vector. Each element is then added to the Slurm
+#' batch file between the `#SBATCH` options and the script's main call. A
+#' common example is adding required modules, e.g. `c("module load gcc/6.1.1")`.
 #'
 NULL

--- a/man/JOB_STATE_CODES.Rd
+++ b/man/JOB_STATE_CODES.Rd
@@ -4,7 +4,9 @@
 \name{JOB_STATE_CODES}
 \alias{JOB_STATE_CODES}
 \title{Slurm Job state codes}
-\format{A data frame with 24 rows and 4 columns.}
+\format{
+A data frame with 24 rows and 4 columns.
+}
 \usage{
 JOB_STATE_CODES
 }

--- a/man/Slurm_EvalQ.Rd
+++ b/man/Slurm_EvalQ.Rd
@@ -18,7 +18,8 @@ Slurm_EvalQ(
   export_env = NULL,
   libPaths = .libPaths(),
   hooks = NULL,
-  overwrite = TRUE
+  overwrite = TRUE,
+  preamble = NULL
 )
 }
 \arguments{
@@ -60,6 +61,10 @@ of R objects on disk.}
 \item{overwrite}{Logical scalar. When \code{TRUE}, if the path specified by
 \code{tmp_path/job_name} already exists, it will overwrite it, otherwise the
 function returns with an error.}
+
+\item{preamble}{Character vector. Each element is then added to the Slurm
+batch file between the \verb{#SBATCH} options and the script's main call. A
+common example is adding required modules, e.g. \code{c("module load gcc/6.1.1")}.}
 }
 \value{
 A list of length \code{njobs}.

--- a/man/Slurm_lapply.Rd
+++ b/man/Slurm_lapply.Rd
@@ -22,7 +22,8 @@ Slurm_Map(
   export_env = NULL,
   libPaths = .libPaths(),
   hooks = NULL,
-  overwrite = TRUE
+  overwrite = TRUE,
+  preamble = NULL
 )
 
 Slurm_lapply(
@@ -42,7 +43,8 @@ Slurm_lapply(
   export_env = NULL,
   libPaths = .libPaths(),
   hooks = NULL,
-  overwrite = TRUE
+  overwrite = TRUE,
+  preamble = NULL
 )
 
 Slurm_sapply(X, FUN, ..., simplify = TRUE, USE.NAMES = TRUE)
@@ -84,6 +86,10 @@ of R objects on disk.}
 \item{overwrite}{Logical scalar. When \code{TRUE}, if the path specified by
 \code{tmp_path/job_name} already exists, it will overwrite it, otherwise the
 function returns with an error.}
+
+\item{preamble}{Character vector. Each element is then added to the Slurm
+batch file between the \verb{#SBATCH} options and the script's main call. A
+common example is adding required modules, e.g. \code{c("module load gcc/6.1.1")}.}
 
 \item{X, FUN, f, mc.cores, ...}{Arguments passed to either \link[parallel:mclapply]{parallel::mclapply} or
 \link[parallel:mclapply]{parallel::mcMap}.}

--- a/man/Slurm_lapply.Rd
+++ b/man/Slurm_lapply.Rd
@@ -86,7 +86,7 @@ of R objects on disk.}
 function returns with an error.}
 
 \item{X, FUN, f, mc.cores, ...}{Arguments passed to either \link[parallel:mclapply]{parallel::mclapply} or
-\link[parallel:mcMap]{parallel::mcMap}.}
+\link[parallel:mclapply]{parallel::mcMap}.}
 
 \item{simplify, USE.NAMES}{Logical scalar. See \link{sapply}.}
 }

--- a/man/makeSlurmCluster.Rd
+++ b/man/makeSlurmCluster.Rd
@@ -8,7 +8,7 @@
 makeSlurmCluster(
   n,
   job_name = random_job_name(),
-  tmp_path = opts_slurmR$get_tmp_path(),
+  tmp_path = dirname(tempdir()),
   cluster_opt = list(),
   max_wait = 300L,
   verb = TRUE,
@@ -59,6 +59,17 @@ associated with it, which allows users to star new processes within those.
 By means of this, we can create Socket, also known as "PSOCK", clusters across
 nodes in a Slurm environment. The name of the hosts are retrieved and passed
 later on to \link[parallel:makeCluster]{parallel::makePSOCKcluster}.
+
+It has been the case that R fails to create the cluster with the following
+message in the Slurm log file:\preformatted{srun: fatal: SLURM_MEM_PER_CPU, SLURM_MEM_PER_GPU, and SLURM_MEM_PER_NODE are mutually exclusive
+}
+
+In such cases, setting the memory, for example, upfront can solve the problem.
+For example:\preformatted{cl <- makeSlurmCluster(20, mem = 20)
+}
+
+If the problem persists, i.e., the cluster cannot be created, make sure that
+your Slurm cluster allows Socket connections between nodes.
 
 The method \code{stopCluster} for \code{slurm_cluster} stops the cluster doing
 the following:

--- a/man/makeSlurmCluster.Rd
+++ b/man/makeSlurmCluster.Rd
@@ -26,7 +26,7 @@ makeSlurmCluster(
 scripts) will be stored. Notice that this path must be accessible by all the
 nodes in the network (See \link{opts_slurmR}).}
 
-\item{cluster_opt}{A list of arguments passed to \link[parallel:makePSOCKcluster]{parallel::makePSOCKcluster}.}
+\item{cluster_opt}{A list of arguments passed to \link[parallel:makeCluster]{parallel::makePSOCKcluster}.}
 
 \item{max_wait}{Integer scalar. Wait time before exiting with error while
 trying to read the nodes information.}
@@ -40,14 +40,14 @@ screen reporting on the status of the job submission.}
 }
 \value{
 A object of class \code{c("slurm_cluster", "SOCKcluster", "cluster")}. It
-is the same as what is returned by \link[parallel:makePSOCKcluster]{parallel::makePSOCKcluster} with the main
+is the same as what is returned by \link[parallel:makeCluster]{parallel::makePSOCKcluster} with the main
 difference that it has two extra attributes:
 \itemize{
 \item \code{SLURM_JOBID} Which is the id of the Job that initialized that cluster.
 }
 }
 \description{
-This function is essentially a wrapper of the function \link[parallel:makePSOCKcluster]{parallel::makePSOCKcluster}.
+This function is essentially a wrapper of the function \link[parallel:makeCluster]{parallel::makePSOCKcluster}.
 \code{makeSlurmCluster} main feature is adding node addresses.
 }
 \details{
@@ -58,7 +58,7 @@ Once a job is submitted via Slurm, the user gets access to the nodes
 associated with it, which allows users to star new processes within those.
 By means of this, we can create Socket, also known as "PSOCK", clusters across
 nodes in a Slurm environment. The name of the hosts are retrieved and passed
-later on to \link[parallel:makePSOCKcluster]{parallel::makePSOCKcluster}.
+later on to \link[parallel:makeCluster]{parallel::makePSOCKcluster}.
 
 The method \code{stopCluster} for \code{slurm_cluster} stops the cluster doing
 the following:

--- a/man/opts_slurmR.Rd
+++ b/man/opts_slurmR.Rd
@@ -5,7 +5,7 @@
 \alias{opts_slurmR}
 \title{Get and set default options for \code{sbatch} and \code{slurmR} internals}
 \format{
-An object of class \code{opts_slurmR} of length 16.
+An object of class \code{opts_slurmR} of length 17.
 }
 \usage{
 opts_slurmR
@@ -51,13 +51,13 @@ Slurm options
 \item \verb{get_tmp_path : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_tmp_path, "desc")}
 \item \verb{set_job_name : function (path, check = TRUE, overwrite = TRUE)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$set_job_name, "desc")}.
 \item \verb{get_job_name : function (check = TRUE)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_job_name, "desc")}
+\item \verb{set_preamble : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$set_preamble, "desc")}
+\item \verb{get_preamble : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_preamble, "desc")}
 }
 
 Other options
 \itemize{
 \item \verb{get_cmd : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_cmd, "desc")}
-\item \verb{set_preamble : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$set_preamble, "desc")}
-\item \verb{get_preamble : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_preamble, "desc")}
 }
 
 For general set/retrieve options
@@ -65,6 +65,12 @@ For general set/retrieve options
 \item \verb{set_opts : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$set_opts, "desc")}
 \item \verb{get_opts_job : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_opts_job, "desc")}
 \item \verb{get_opts_r : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_opts_r, "desc")}
+}
+
+Nuke
+\itemize{
+\item While reloading the package should reset all the options, if needed, the user
+can also use the function \code{opts_slurmR$reset()}.
 }
 }
 \examples{

--- a/man/opts_slurmR.Rd
+++ b/man/opts_slurmR.Rd
@@ -4,14 +4,18 @@
 \name{opts_slurmR}
 \alias{opts_slurmR}
 \title{Get and set default options for \code{sbatch} and \code{slurmR} internals}
-\format{An object of class \code{opts_slurmR} of length 14.}
+\format{
+An object of class \code{opts_slurmR} of length 16.
+}
 \usage{
 opts_slurmR
 }
 \description{
 Most of the functions in the \code{slurmR} package use \code{tmp_path} and \code{job-name}
 options to write and submit jobs to \strong{Slurm}. These options have global
-defaults that are set and retrieved using \code{opts_slurmR}.
+defaults that are set and retrieved using \code{opts_slurmR}. These options
+also include SBATCH options and things to do before calling RScript,
+e.g., loading modules on an HPC cluster.
 }
 \details{
 Whatever the path specified on \code{tmp_path}, all nodes should have access to it.
@@ -21,6 +25,9 @@ See for example \href{https://en.wikipedia.org/w/index.php?title=Disk_staging&ol
 The \code{tmp_path} directory is only created at the time that one of the functions
 needs to I/O files. Job creation calls like \link{Slurm_EvalQ} and \link{Slurm_lapply}
 do such.
+
+The "preamble" options can be specified if, for example, the current cluster
+needs to load R, a compiler, or other programs via a \code{module} command.
 
 Current supported options are:
 
@@ -49,6 +56,8 @@ Slurm options
 Other options
 \itemize{
 \item \verb{get_cmd : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_cmd, "desc")}
+\item \verb{set_preamble : function (...)} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$set_preamble, "desc")}
+\item \verb{get_preamble : function ()} \Sexpr[stage=build]{attr(slurmR::opts_slurmR$get_preamble, "desc")}
 }
 
 For general set/retrieve options
@@ -65,6 +74,7 @@ For general set/retrieve options
 opts_slurmR$set_tmp_path("/staging/pdt/vegayon")
 opts_slurmR$set_job_name("simulations-1")
 opts_slurm$set_opts(partition="thomas", account="lc_pdt")
+opts_slurm$set_preamble("module load gcc")# if needed
 }
 
 }

--- a/man/slurmR.Rd
+++ b/man/slurmR.Rd
@@ -5,7 +5,13 @@
 \alias{slurmR}
 \title{A Lightweight Wrapper for 'Slurm'}
 \description{
-A Lightweight Wrapper for 'Slurm'
+'Slurm', Simple Linux Utility for Resource Management
+\url{https://slurm.schedmd.com/}, is a popular 'Linux' based software used to
+schedule jobs in 'HPC' (High Performance Computing) clusters. This R package
+provides a specialized lightweight wrapper of 'Slurm' with a syntax similar to
+that found in the 'parallel' R package. The package also includes a method for
+creating socket cluster objects spanning multiple nodes that can be used with
+the 'parallel' package.
 }
 \details{
 To cite slurmR in publications use:

--- a/man/sourceSlurm.Rd
+++ b/man/sourceSlurm.Rd
@@ -8,7 +8,7 @@
 sourceSlurm(
   file,
   job_name = NULL,
-  tmp_path = tempdir(),
+  tmp_path = file.path(tempdir(), ".."),
   rscript_opt = list(vanilla = TRUE),
   plan = "submit",
   ...

--- a/man/sourceSlurm.Rd
+++ b/man/sourceSlurm.Rd
@@ -8,7 +8,7 @@
 sourceSlurm(
   file,
   job_name = NULL,
-  tmp_path = file.path(tempdir(), ".."),
+  tmp_path = dirname(tempdir()),
   rscript_opt = list(vanilla = TRUE),
   plan = "submit",
   ...

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -4,8 +4,8 @@ if ( requireNamespace("tinytest", quietly=TRUE) & (.Platform$OS.type == "unix") 
 
   library(slurmR)
   if (slurm_available()) {
-    opts_slurmR$set_tmp_path("/staging/ggv/slurmR-tinytest/")
-    opts_slurmR$set_opts(partition = "thomas", account = "lc_pdt")
+    opts_slurmR$set_tmp_path("/scratch/vegayon/ggv/slurmR-rcmdcheck/")
+    opts_slurmR$set_opts(account = "pdthomas_136")
   } else {
     opts_slurmR$set_tmp_path(tempdir())
   }


### PR DESCRIPTION
This addresses #28. This patch includes a few minor tweaks to the code and a new feature that allows users to add command lines between the `#SBATCH` options and the call to `Rscript`, e.g.:

```r
opts_slurmR$set_preamble("module load gcc/6.0.0")
```

